### PR TITLE
Make the email regex m.better

### DIFF
--- a/scripts/ayp.coffee
+++ b/scripts/ayp.coffee
@@ -86,7 +86,7 @@ filterText = (text) ->
   text = text.replace(/(https?:\/\/[^\s]+)/, "[redacted]")
   
   # Emails 'R' Secret
-  text = text.replace(/(?![^@\s]+@)[^@\s]+\.[^@\s]+/, "[redacted]")
+  text = text.replace(/([^@\s]+@)[^@\s]+\.[^@\s]+/, "$1[redacted]")
 
   # Twitter length, then truncate with `...`
   limit = 140


### PR DESCRIPTION
The email regular expression is [redact]ing any word that has a period in it, like @sshirokov's "p.good" statements. This removes the insane regex look ahead thing to use a capture group instead to ensure we just [redact] email domains.