### PR TITLE
Add a script for fetching the minecraft server status.

### DIFF
--- a/scripts/mcstatus.coffee
+++ b/scripts/mcstatus.coffee
@@ -1,0 +1,49 @@
+# Description:
+#   Report the status of a Minecraft server
+#   Uses http://api.syfaro.net/
+#
+# Dependencies:
+#   None
+#
+# Configuration:
+#   server_url and server_port, below
+#
+# Commands:
+#   mcstatus - Report the status of the configured minecraft server.
+#
+# Author:
+#   annabunches
+
+default_url = 'mc.wtf.cat'
+default_port = '10070'
+
+get_mc_server_status = (msg, url, port) ->
+  msg.http(request_url)
+  .header(Accept: 'application/json')
+  .get() (err, res, body) ->
+
+    request_url = "http://api.syfaro.net/server/status?ip=#{url}&port=#{port}&players=true"
+    
+    if err?
+      msg.send "Error: #{err}"
+      return
+    try
+      data = JSON.parse(body)
+    catch error
+      msg.send "Error parsing JSON"
+      return
+
+    if not data.online
+      status = "offline."
+    else
+      status = "online, with #{data.players.now}/#{data.players.max} players."
+      
+      if data.players.now > 0
+        status += ' (' + [player.name for player in data.players.sample].join(', ') + ')'
+
+    msg.send "Minecraft server #{url}:#{port} is #{status}"
+
+
+module.exports = (robot) ->
+  robot.respond /mcstatus/i, (res) ->
+    get_mc_server_status(res, default_url, default_port)

--- a/scripts/mcstatus.coffee
+++ b/scripts/mcstatus.coffee
@@ -6,16 +6,16 @@
 #   None
 #
 # Configuration:
-#   server_url and server_port, below
+#   MINECRAFT_HOST and MINECRAFT_PORT
 #
 # Commands:
-#   mcstatus - Report the status of the configured minecraft server.
+#   mcstatus [host] [port] - Report the status of a minecraft server.
 #
 # Author:
 #   annabunches
 
-default_url = 'mc.wtf.cat'
-default_port = '10070'
+default_url = process.env.MINECRAFT_HOST
+default_port = process.env.MINECRAFT_PORT
 
 get_mc_server_status = (msg, url, port) ->
   request_url = "http://api.syfaro.net/server/status?ip=#{url}&port=#{port}&players=true"
@@ -44,5 +44,7 @@ get_mc_server_status = (msg, url, port) ->
 
 
 module.exports = (robot) ->
-  robot.respond /mcstatus/i, (res) ->
-    get_mc_server_status(res, default_url, default_port)
+  robot.respond /mcstatus( +\S+)?( +\d+)?/i, (res) ->
+    host = res.match[1]?.trim() || process.env.MINECRAFT_HOST
+    port = res.match[2]?.trim() || process.env.MINECRAFT_PORT
+    get_mc_server_status(res, host, port)

--- a/scripts/mcstatus.coffee
+++ b/scripts/mcstatus.coffee
@@ -18,12 +18,11 @@ default_url = 'mc.wtf.cat'
 default_port = '10070'
 
 get_mc_server_status = (msg, url, port) ->
+  request_url = "http://api.syfaro.net/server/status?ip=#{url}&port=#{port}&players=true"
+
   msg.http(request_url)
   .header(Accept: 'application/json')
   .get() (err, res, body) ->
-
-    request_url = "http://api.syfaro.net/server/status?ip=#{url}&port=#{port}&players=true"
-    
     if err?
       msg.send "Error: #{err}"
       return


### PR DESCRIPTION
Does what it says on the tin. Verified manually that it works, but no unit test coverage yet because testing is difficult and I can't figure out how to successfully fetch/mock responses to an external http server. (I think maybe sinon can do it, but I haven't been able to puzzle out how just yet)

I figured testing coverage wasn't critical enough to block the pull request, though.