### PR TITLE
Clean up a minor syntax issue raised in the previous PR.

### DIFF
--- a/scripts/vote.coffee
+++ b/scripts/vote.coffee
@@ -130,8 +130,7 @@ Supported commands:
   # Election driver
   robot.respond /(?:vote|freedom|oppressed) (\d+ )?([^\s]+)\s?(.*)?$/, (msg) ->
     timeout = 1 # default timeout is 1 minute
-    if msg.match[1] and msg.match[1].length > 0
-      timeout = parseInt(msg.match[1].trim())
+    timeout = parseInt(msg.match[1].trim()) if msg.match[1]?.length > 0
 
     action = msg.match[2].trim().toLowerCase()
     arg = msg.match[3]?.trim()


### PR DESCRIPTION
As per suggested comments. Notably (and slightly off topic) the 'this.clock' issue referenced by drobati is required, because 'clock' is some sort of dark magical js built-in (as far as I can tell)